### PR TITLE
Fix to "TypeError: __init__() got an unexpected keyword argument `safe`"

### DIFF
--- a/pyramid_debugtoolbar_mongo/operation_tracker.py
+++ b/pyramid_debugtoolbar_mongo/operation_tracker.py
@@ -47,13 +47,12 @@ def _get_stacktrace():
 # Wrap Cursor._refresh for getting queries
 @functools.wraps(_original_methods['insert'])
 def _insert(collection_self, doc_or_docs, manipulate=True,
-            safe=False, check_keys=True, **kwargs):
+            check_keys=True, **kwargs):
     start_time = time.time()
     result = _original_methods['insert'](
         collection_self,
         doc_or_docs,
         manipulate=manipulate,
-        safe=safe,
         check_keys=check_keys,
         **kwargs
     )
@@ -62,7 +61,7 @@ def _insert(collection_self, doc_or_docs, manipulate=True,
     __traceback_hide__ = True
     inserts.append({
         'document': doc_or_docs,
-        'safe': safe,
+        'safe': kwargs.get('safe', False),
         'time': total_time,
         'stack_trace': _get_stacktrace(),
     })
@@ -72,14 +71,13 @@ def _insert(collection_self, doc_or_docs, manipulate=True,
 # Wrap Cursor._refresh for getting queries
 @functools.wraps(_original_methods['update'])
 def _update(collection_self, spec, document, upsert=False,
-            maniuplate=False, safe=False, multi=False, **kwargs):
+            maniuplate=False, multi=False, **kwargs):
     start_time = time.time()
     result = _original_methods['update'](
         collection_self,
         spec,
         document,
         upsert=upsert,
-        safe=safe,
         multi=multi,
         **kwargs
     )
@@ -91,7 +89,7 @@ def _update(collection_self, spec, document, upsert=False,
         'upsert': upsert,
         'multi': multi,
         'spec': spec,
-        'safe': safe,
+        'safe': kwargs.get('safe', False),
         'time': total_time,
         'stack_trace': _get_stacktrace(),
     })
@@ -100,19 +98,18 @@ def _update(collection_self, spec, document, upsert=False,
 
 # Wrap Cursor._refresh for getting queries
 @functools.wraps(_original_methods['remove'])
-def _remove(collection_self, spec_or_id, safe=False, **kwargs):
+def _remove(collection_self, spec_or_id, **kwargs):
     start_time = time.time()
     result = _original_methods['remove'](
         collection_self,
         spec_or_id,
-        safe=safe,
         **kwargs
     )
     total_time = (time.time() - start_time) * 1000
 
     removes.append({
         'spec_or_id': spec_or_id,
-        'safe': safe,
+        'safe': kwargs.get('safe', False),
         'time': total_time,
         'stack_trace': _get_stacktrace(),
     })


### PR DESCRIPTION
The project works wonderfully and is helping me a lot, but I stumbled on this error when trying to login:

```Traceback (most recent call last):
  File "/var/virtual_envs/pyzze/lib/python2.7/site-packages/pyramid_debugtoolbar/panels/performance.py", line 57, in resource_timer_handler
    result = handler(request)
  File "/var/virtual_envs/pyzze/lib/python2.7/site-packages/pyramid/tweens.py", line 48, in excview_tween
    request_iface=request_iface.combined
  File "/var/virtual_envs/pyzze/lib/python2.7/site-packages/pyramid/view.py", line 541, in _call_view
    response = view_callable(context, request)
  File "/var/virtual_envs/pyzze/lib/python2.7/site-packages/pyramid/config/views.py", line 385, in viewresult_to_response
    result = view(context, request)
  File "/home/jayme/pyzze/pyzzeapps/pyzzeapps/views.py", line 64, in failed_validation
    return handle_failed_validation(request, sentryclient)
  File "/var/virtual_envs/pyzze/lib/python2.7/site-packages/pyramid/tweens.py", line 20, in excview_tween
    response = handler(request)
  File "/var/virtual_envs/pyzze/lib/python2.7/site-packages/pyramid/router.py", line 145, in handle_request
    view_name
  File "/var/virtual_envs/pyzze/lib/python2.7/site-packages/pyramid/view.py", line 541, in _call_view
    response = view_callable(context, request)
  File "/var/virtual_envs/pyzze/lib/python2.7/site-packages/pyramid/config/views.py", line 353, in rendered_view
    result = view(context, request)
  File "/var/virtual_envs/pyzze/lib/python2.7/site-packages/pyramid/config/views.py", line 507, in _requestonly_view
    response = view(request)
  File "/home/jayme/pyzze/pyzzeapps/pyzzeapps/login.py", line 221, in login
    return authorize(request, user) #call extracted method
  File "/home/jayme/pyzze/pyzzeapps/pyzzeapps/login.py", line 181, in authorize
    request.session['credentials'] = get_google_certificate_credentials(user.get('email', ''))
  File "/home/jayme/pyzze/pyzzeapps/pyzzeapps/login.py", line 306, in get_google_certificate_credentials
    **{'private key' : key_file_name}
  File "/home/jayme/pyzze/pyzzeapps/pyzzeapps/__init__.py", line 201, in mail_exception_for_devs
    log_email(request, messager)
  File "/home/jayme/pyzze/pyzze-utils/pyzze_utils/common_views/helper.py", line 156, in log_email
    raise e
TypeError: __init__() got an unexpected keyword argument 'safe'```

It seems to be caused by the "safe" key being sent to pymongo.
This solution worked for me. I'm not sure if this doesn't break anything else. But here it is. ;)

I'm running the build on [travis](https://travis-ci.com/kalkehcoisa/pyramid_debugtoolbar_mongo/builds/120785851). It's breaking for some python versions because it's not able to download them - for whatever reason I don't know.